### PR TITLE
Upsert, pre-create internal topics, and print topology on load

### DIFF
--- a/setup
+++ b/setup
@@ -9,6 +9,10 @@ setup_dedicated () {
     heroku kafka:topics:create textlines --partitions 5 -a ${APP_NAME} && \
     heroku kafka:topics:create words --partitions 5 -a ${APP_NAME} && \
     heroku kafka:topics:create loglines --partitions 5 -a ${APP_NAME}
+    heroku kafka:topics:create aggregator-app-windowed-counts-changelog --partitions 5 -a ${APP_NAME} && \
+    heroku kafka:topics:create aggregator-app-windowed-counts-repartition --partitions 5 -a ${APP_NAME} && \
+    heroku kafka:topics:create anomaly-detector-app-windowed-counts-changelog --partitions 5 -a ${APP_NAME} && \
+    heroku kafka:topics:create anomaly-detector-app-windowed-counts-repartition --partitions 5 -a ${APP_NAME} && \
 }
 
 setup_multi_tenant () {

--- a/setup
+++ b/setup
@@ -50,7 +50,8 @@ else
   setup_dedicated
 fi
 
-heroku pg:psql -c 'create table windowed_counts(id serial primary key not null, time_window bigint not null, word text, count bigint not null);' HEROKU_POSTGRESQL_URL -a ${APP_NAME}
+heroku pg:psql -c 'CREATE TABLE windowed_counts(id serial primary key NOT NULL, time_window bigint NOT NULL, word text, count bigint NOT NULL);' HEROKU_POSTGRESQL_URL -a ${APP_NAME}
+heroku pg:psql -c 'CREATE UNIQUE INDEX windowed_counts_time_window_word ON windowed_counts(word text_ops,time_window int8_ops);' HEROKU_POSTGRESQL_URL -a ${APP_NAME}
 
 heroku ps:scale text_processor_worker=1 -a ${APP_NAME}
 heroku ps:scale aggregator_worker=1 -a ${APP_NAME}

--- a/streams-aggregator/src/main/java/io/jeffchao/streams/aggregator/Aggregator.java
+++ b/streams-aggregator/src/main/java/io/jeffchao/streams/aggregator/Aggregator.java
@@ -16,6 +16,7 @@ import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.kstream.TimeWindows;
 import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.Topology;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/streams-aggregator/src/main/java/io/jeffchao/streams/aggregator/Aggregator.java
+++ b/streams-aggregator/src/main/java/io/jeffchao/streams/aggregator/Aggregator.java
@@ -48,6 +48,9 @@ public class Aggregator {
         .process(PostgresSink::new);
 
     final Topology topology = builder.build();
+
+    // Log topology at startup, for debugging
+    // More about the topology graph: https://www.confluent.io/blog/optimizing-kafka-streams-applications
     System.out.println(topology.describe());
 
     final KafkaStreams streams = new KafkaStreams(topology, streamsConfig);

--- a/streams-aggregator/src/main/java/io/jeffchao/streams/aggregator/Aggregator.java
+++ b/streams-aggregator/src/main/java/io/jeffchao/streams/aggregator/Aggregator.java
@@ -46,7 +46,10 @@ public class Aggregator {
         .toStream()
         .process(PostgresSink::new);
 
-    final KafkaStreams streams = new KafkaStreams(builder.build(), streamsConfig);
+    final Topology topology = builder.build();
+    System.out.println(topology.describe());
+
+    final KafkaStreams streams = new KafkaStreams(topology, streamsConfig);
 
     streams.cleanUp();
     streams.start();

--- a/streams-aggregator/src/main/java/io/jeffchao/streams/aggregator/sinks/PostgresSink.java
+++ b/streams-aggregator/src/main/java/io/jeffchao/streams/aggregator/sinks/PostgresSink.java
@@ -11,7 +11,6 @@ import java.util.Optional;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.processor.Processor;
 import org.apache.kafka.streams.processor.ProcessorContext;
-import org.apache.kafka.streams;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/streams-aggregator/src/main/java/io/jeffchao/streams/aggregator/sinks/PostgresSink.java
+++ b/streams-aggregator/src/main/java/io/jeffchao/streams/aggregator/sinks/PostgresSink.java
@@ -46,10 +46,11 @@ public class PostgresSink implements Processor<Windowed<String>, Long> {
     log.info("writing to pg: window: {}, key: {}, value: {}", key.window(), key.key(), value);
     try {
       PreparedStatement statement = connection.prepareStatement(
-          "INSERT INTO windowed_counts (time_window, word, count) VALUES (?, ?, ?)");
+          "INSERT INTO windowed_counts (time_window, word, count) VALUES (?, ?, ?) ON CONFLICT (time_window, word) DO UPDATE count = ?");
       statement.setLong(1, key.window().start());
       statement.setString(2, key.key());
       statement.setLong(3, value);
+      statement.setLong(4, value);
 
       statement.execute();
     } catch (SQLException e) {

--- a/streams-aggregator/src/main/java/io/jeffchao/streams/aggregator/sinks/PostgresSink.java
+++ b/streams-aggregator/src/main/java/io/jeffchao/streams/aggregator/sinks/PostgresSink.java
@@ -11,6 +11,7 @@ import java.util.Optional;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.processor.Processor;
 import org.apache.kafka.streams.processor.ProcessorContext;
+import org.apache.kafka.streams.Topology;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/streams-aggregator/src/main/java/io/jeffchao/streams/aggregator/sinks/PostgresSink.java
+++ b/streams-aggregator/src/main/java/io/jeffchao/streams/aggregator/sinks/PostgresSink.java
@@ -46,7 +46,7 @@ public class PostgresSink implements Processor<Windowed<String>, Long> {
     log.info("writing to pg: window: {}, key: {}, value: {}", key.window(), key.key(), value);
     try {
       PreparedStatement statement = connection.prepareStatement(
-          "INSERT INTO windowed_counts (time_window, word, count) VALUES (?, ?, ?) ON CONFLICT (time_window, word) DO UPDATE count = ?");
+          "INSERT INTO windowed_counts (time_window, word, count) VALUES (?, ?, ?) ON CONFLICT (time_window, word) DO UPDATE SET count = ?");
       statement.setLong(1, key.window().start());
       statement.setString(2, key.key());
       statement.setLong(3, value);

--- a/streams-aggregator/src/main/java/io/jeffchao/streams/aggregator/sinks/PostgresSink.java
+++ b/streams-aggregator/src/main/java/io/jeffchao/streams/aggregator/sinks/PostgresSink.java
@@ -46,11 +46,12 @@ public class PostgresSink implements Processor<Windowed<String>, Long> {
     log.info("writing to pg: window: {}, key: {}, value: {}", key.window(), key.key(), value);
     try {
       PreparedStatement statement = connection.prepareStatement(
-          "INSERT INTO windowed_counts (time_window, word, count) VALUES (?, ?, ?)");
+          "INSERT INTO windowed_counts (time_window, word, count) VALUES (?, ?, ?) ON CONFLICT (time_window, word) DO UPDATE SET count = ?");
       statement.setLong(1, key.window().start());
       statement.setString(2, key.key());
       statement.setLong(3, value);
-
+      statement.setLong(4, value);
+      
       statement.execute();
     } catch (SQLException e) {
       log.error(e.getMessage(), e);

--- a/streams-aggregator/src/main/java/io/jeffchao/streams/aggregator/sinks/PostgresSink.java
+++ b/streams-aggregator/src/main/java/io/jeffchao/streams/aggregator/sinks/PostgresSink.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.processor.Processor;
 import org.apache.kafka.streams.processor.ProcessorContext;
-import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 


### PR DESCRIPTION
This PR makes the following changes:

1. Upsert to Postgres instead of inserting. Inserting rows results in many intermediate values being written to Postgres.
2. Create internal topics for dedicated Kafka plans. Without this step, Streams failed to create the internal topics it needed to run due to Heroku Kafka ACL's.
3. Print Kafka Streams topology on load. This is helpful for troubleshooting.

@jkutner happy to discuss - some of these could be split out.